### PR TITLE
feat: Add format version to config and parse based on that

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v2.1.6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,73 +1,76 @@
+version: "2"
 linters:
   enable:
-    - bidichk # checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - decorder # checks declaration order and count of types, constants, variables and functions
-    - errcheck # checking for unchecked errors
-    - errchkjson # Checks types passed to the json encoding functions
-    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-    - copyloopvar # checks for pointers to enclosing loop variables
-    - forbidigo # forbids identifiers
-    - funlen # tool for detection of long functions
-    - goconst # finds repeated strings that could be replaced by a constant
-    - gocritic # provides diagnostics that check for bugs, performance and style issues
-    - gocyclo # computes and checks the cyclomatic complexity of functions
-    - gosimple # specializes in simplifying a code
-    - gosec # inspects source code for security problems
-    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # detects when assignments to existing variables are not used
-    - lll # limit line length
-    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
-    - nolintlint # reports ill-formed or insufficient nolint directives
-    - predeclared # finds code that shadows one of Go's predeclared identifiers
-    - revive # drop-in replacement of golint
-    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
-    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    - unconvert # removes unnecessary type conversions
-    - unparam # reports unused function parameters
-    - unused # checks for unused constants, variables, functions and types
-    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
-    - goimports # checks if the code is correctly formatted and imports are in order
-    - nilerr # checks for errors that are compared to nil
-    - whitespace # checks for leading and trailing white spaces
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - funlen
-        - govet
-        - bodyclose
-        - errchkjson
-        - goconst
-        - gosec
-        - unparam
-        - errcheck
-    - path: \.gen\.go
-      linters:
-        - funlen
-        - govet
-    # Exclude `lll` issues for long lines with `go:generate`.
-    - linters:
-        - lll
-      source: "^//go:generate "
-linters-settings:
-  revive:
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - decorder
+    - errchkjson
+    - errorlint
+    - forbidigo
+    - funlen
+    - goconst
+    - gocritic
+    - gocyclo
+    - gosec
+    - lll
+    - nilerr
+    - nilnil
+    - nolintlint
+    - predeclared
+    - revive
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - whitespace
+  settings:
+    funlen:
+      ignore-comments: true
+    gosec:
+      excludes:
+        - G304
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    lll:
+      line-length: 130
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - []
+  exclusions:
+    generated: lax
     rules:
-      - name: var-naming # enable this to check for stuff like Xml -> XML naming
-        arguments:
-          - []
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  lll:
-    # Max line length, lines longer will be reported.
-    line-length: 130
-  funlen:
-    ignore-comments: true
-  gosec:
-    excludes:
-      - G304 # Potential file inclusion via variable
+      - linters:
+          - bodyclose
+          - errcheck
+          - errchkjson
+          - funlen
+          - goconst
+          - gosec
+          - govet
+          - unparam
+        path: _test\.go
+      - linters:
+          - funlen
+          - govet
+        path: \.gen\.go
+      - linters:
+          - lll
+        source: '^//go:generate '
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -2,13 +2,14 @@ package cfg
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"gopkg.in/yaml.v2"
 )
+
+const currentFormatVersion = 2
 
 type Task struct {
 	IssueID     string
@@ -22,6 +23,8 @@ type Config struct {
 	JiraURL     string `yaml:"jira_url"`
 	JiraToken   string `yaml:"jira_token"`
 	JiraProject string `yaml:"jira_project"`
+
+	FormatVersion int `yaml:"format_version"`
 
 	Tasks map[string]Task `yaml:"tasks"`
 
@@ -40,6 +43,7 @@ type AskForConfig func() *Config
 
 func NewConfg() Config {
 	return Config{
+		// FormatVersion will be set by LoadOrCreateConfig or Save
 		Tasks: map[string]Task{},
 		lock:  &sync.Mutex{},
 	}
@@ -55,20 +59,49 @@ func LoadOrCreateConfig(askForConfig AskForConfig) (*Config, error) {
 	file, err := os.Open(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			config := askForConfig()
-			return config, config.Save()
+			newCfg := askForConfig()
+			// Initialize fields that NewConfg would, and set current format version
+			newCfg.FormatVersion = currentFormatVersion
+			if newCfg.lock == nil {
+				newCfg.lock = &sync.Mutex{}
+			}
+			if newCfg.Tasks == nil {
+				newCfg.Tasks = make(map[string]Task)
+			}
+			// Save will also ensure FormatVersion is currentFormatVersion
+			return newCfg, newCfg.Save()
 		}
-		log.Fatalf("Failed to open config file: %v", err)
+		return nil, fmt.Errorf("Failed to open config file: %w", err)
 	}
 	defer func() {
 		_ = file.Close()
 	}()
 
-	var config Config = NewConfg()
+	var config Config
+	// Initialize non-yaml fields manually before decode
+	config.lock = &sync.Mutex{}
+	// Tasks map will be populated by decoder if present in YAML, otherwise needs init
+	// config.Tasks = make(map[string]Task) // Let decoder handle this or init after.
+
 	decoder := yaml.NewDecoder(file)
 	if err := decoder.Decode(&config); err != nil {
+		// If decoding fails, it might be an empty or malformed file.
+		// For this specific case, we might want to treat it as "not exist"
+		// and create a new one, but the current logic is to error out.
+		// For now, let's stick to the error.
 		return nil, fmt.Errorf("Failed to decode config file: %w", err)
 	}
+
+	// After successful decode, handle versioning and ensure essential maps/locks
+	if config.FormatVersion == 0 { // If FormatVersion was missing in the file (or explicitly 0)
+		config.FormatVersion = 1 // This is an old config (version 1)
+	}
+
+	// Ensure Tasks map is initialized if it was nil (e.g. empty or old config file)
+	if config.Tasks == nil {
+		config.Tasks = make(map[string]Task)
+	}
+	// Lock should have been initialized above.
 
 	return &config, nil
 }
@@ -76,6 +109,8 @@ func LoadOrCreateConfig(askForConfig AskForConfig) (*Config, error) {
 func (c *Config) Save() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
+	c.FormatVersion = currentFormatVersion
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -52,7 +52,7 @@ func NewConfg() Config {
 func LoadOrCreateConfig(askForConfig AskForConfig) (*Config, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get home directory: %w", err)
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 
 	configPath := filepath.Join(homeDir, ".gg")
@@ -71,7 +71,7 @@ func LoadOrCreateConfig(askForConfig AskForConfig) (*Config, error) {
 			// Save will also ensure FormatVersion is currentFormatVersion
 			return newCfg, newCfg.Save()
 		}
-		return nil, fmt.Errorf("Failed to open config file: %w", err)
+		return nil, fmt.Errorf("failed to open config file: %w", err)
 	}
 	defer func() {
 		_ = file.Close()
@@ -89,7 +89,7 @@ func LoadOrCreateConfig(askForConfig AskForConfig) (*Config, error) {
 		// For this specific case, we might want to treat it as "not exist"
 		// and create a new one, but the current logic is to error out.
 		// For now, let's stick to the error.
-		return nil, fmt.Errorf("Failed to decode config file: %w", err)
+		return nil, fmt.Errorf("failed to decode config file: %w", err)
 	}
 
 	// After successful decode, handle versioning and ensure essential maps/locks
@@ -114,13 +114,13 @@ func (c *Config) Save() error {
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("Failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get home directory: %w", err)
 	}
 
 	configPath := filepath.Join(homeDir, ".gg")
 	file, err := os.Create(configPath)
 	if err != nil {
-		return fmt.Errorf("Failed to create config file: %w", err)
+		return fmt.Errorf("failed to create config file: %w", err)
 	}
 	defer func() {
 		_ = file.Close()
@@ -128,7 +128,7 @@ func (c *Config) Save() error {
 
 	encoder := yaml.NewEncoder(file)
 	if err := encoder.Encode(c); err != nil {
-		return fmt.Errorf("Failed to encode config file: %w", err)
+		return fmt.Errorf("failed to encode config file: %w", err)
 	}
 
 	return nil

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -91,7 +91,7 @@ tasks: {}
 	if loadedCfg.lock == nil {
 		loadedCfg.lock = &sync.Mutex{}
 	}
-	
+
 	err = loadedCfg.Save()
 	if err != nil {
 		t.Fatalf("Save failed: %v", err)
@@ -157,7 +157,7 @@ func TestCreateNewConfig(t *testing.T) {
 	if createdCfg.FormatVersion != testCurrentFormatVersion {
 		t.Errorf("Expected FormatVersion to be %d for new config, got %d", testCurrentFormatVersion, createdCfg.FormatVersion)
 	}
-	
+
 	// Ensure lock is initialized
 	if createdCfg.lock == nil {
 		createdCfg.lock = &sync.Mutex{}
@@ -206,7 +206,7 @@ tasks: {}
 	if loadedCfg.lock == nil {
 		loadedCfg.lock = &sync.Mutex{}
 	}
-	
+
 	err = loadedCfg.Save()
 	if err != nil {
 		t.Fatalf("Save failed: %v", err)

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -29,11 +29,21 @@ func createTempConfigFile(t *testing.T, content string) string {
 	// Override user home dir to point to our temp dir for the duration of the test
 	// so LoadOrCreateConfig and Save work with our temp file.
 	originalHomeDir, present := os.LookupEnv("HOME")
-	t.Setenv("HOME", tempDir)
+	if err := os.Setenv("HOME", tempDir); err != nil {
+		t.Fatalf("Failed to set HOME env var: %v", err)
+	}
 	if present {
-		t.Cleanup(func() { os.Setenv("HOME", originalHomeDir) })
+		t.Cleanup(func() {
+			if err := os.Setenv("HOME", originalHomeDir); err != nil {
+				t.Fatalf("Failed to restore HOME env var: %v", err)
+			}
+		})
 	} else {
-		t.Cleanup(func() { os.Unsetenv("HOME") })
+		t.Cleanup(func() {
+			if err := os.Unsetenv("HOME"); err != nil {
+				t.Fatalf("Failed to unset HOME env var: %v", err)
+			}
+		})
 	}
 
 	return tmpFile.Name()
@@ -97,13 +107,23 @@ func TestCreateNewConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	// Override user home dir to point to our temp dir for the duration of the test
 	originalHomeDir, present := os.LookupEnv("HOME")
-	t.Setenv("HOME", tempDir)
-	if present {
-		t.Cleanup(func() { os.Setenv("HOME", originalHomeDir) })
-	} else {
-		t.Cleanup(func() { os.Unsetenv("HOME") })
+	if err := os.Setenv("HOME", tempDir); err != nil {
+		t.Fatalf("Failed to set HOME env var: %v", err)
 	}
-	
+	if present {
+		t.Cleanup(func() {
+			if err := os.Setenv("HOME", originalHomeDir); err != nil {
+				t.Fatalf("Failed to restore HOME env var: %v", err)
+			}
+		})
+	} else {
+		t.Cleanup(func() {
+			if err := os.Unsetenv("HOME"); err != nil {
+				t.Fatalf("Failed to unset HOME env var: %v", err)
+			}
+		})
+	}
+
 	// Ensure no config file exists initially
 	configFilePath := filepath.Join(tempDir, ".gg")
 	if _, err := os.Stat(configFilePath); !os.IsNotExist(err) {

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -1,0 +1,199 @@
+package cfg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+const testCurrentFormatVersion = 2
+
+// Helper function to create a temporary config file
+func createTempConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	tmpFile, err := os.Create(filepath.Join(tempDir, ".gg"))
+	if err != nil {
+		t.Fatalf("Failed to create temp config file: %v", err)
+	}
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("Failed to write to temp config file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temp config file: %v", err)
+	}
+	// Override user home dir to point to our temp dir for the duration of the test
+	// so LoadOrCreateConfig and Save work with our temp file.
+	originalHomeDir, present := os.LookupEnv("HOME")
+	t.Setenv("HOME", tempDir)
+	if present {
+		t.Cleanup(func() { os.Setenv("HOME", originalHomeDir) })
+	} else {
+		t.Cleanup(func() { os.Unsetenv("HOME") })
+	}
+
+	return tmpFile.Name()
+}
+
+// Helper function to read and unmarshal a config file
+func loadConfigFromFile(t *testing.T, path string) *Config {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read config file %s: %v", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal config from %s: %v", path, err)
+	}
+	return &cfg
+}
+
+func TestLoadExistingConfigWithoutVersion(t *testing.T) {
+	configContent := `
+jira_user: testuser
+jira_url: https://test.jira.com
+jira_token: sometoken
+jira_project: TEST
+tasks: {}
+`
+	configFile := createTempConfigFile(t, configContent)
+
+	mockAskFn := func() *Config {
+		t.Error("AskForConfig should not be called when a config file exists")
+		return &Config{FormatVersion: 99, lock: &sync.Mutex{}} // Should not happen
+	}
+
+	loadedCfg, err := LoadOrCreateConfig(mockAskFn)
+	if err != nil {
+		t.Fatalf("LoadOrCreateConfig failed: %v", err)
+	}
+
+	if loadedCfg.FormatVersion != 1 {
+		t.Errorf("Expected FormatVersion to be 1 for old config, got %d", loadedCfg.FormatVersion)
+	}
+
+	// Ensure lock is initialized
+	if loadedCfg.lock == nil {
+		loadedCfg.lock = &sync.Mutex{}
+	}
+	
+	err = loadedCfg.Save()
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	savedCfg := loadConfigFromFile(t, configFile)
+	if savedCfg.FormatVersion != testCurrentFormatVersion {
+		t.Errorf("Expected FormatVersion in saved file to be %d, got %d", testCurrentFormatVersion, savedCfg.FormatVersion)
+	}
+}
+
+func TestCreateNewConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	// Override user home dir to point to our temp dir for the duration of the test
+	originalHomeDir, present := os.LookupEnv("HOME")
+	t.Setenv("HOME", tempDir)
+	if present {
+		t.Cleanup(func() { os.Setenv("HOME", originalHomeDir) })
+	} else {
+		t.Cleanup(func() { os.Unsetenv("HOME") })
+	}
+	
+	// Ensure no config file exists initially
+	configFilePath := filepath.Join(tempDir, ".gg")
+	if _, err := os.Stat(configFilePath); !os.IsNotExist(err) {
+		t.Fatalf("Config file %s should not exist at the start of this test, but it does.", configFilePath)
+	}
+
+	var askFnCalled bool
+	mockAskFn := func() *Config {
+		askFnCalled = true
+		// Create a new config like the main NewConfg would, including setting version
+		return &Config{
+			JiraUser:      "newuser",
+			JiraURL:       "https://new.jira.com",
+			JiraToken:     "newtoken",
+			JiraProject:   "NEW",
+			FormatVersion: testCurrentFormatVersion, // NewConfg now sets this
+			Tasks:         map[string]Task{},
+			lock:          &sync.Mutex{},
+		}
+	}
+
+	createdCfg, err := LoadOrCreateConfig(mockAskFn)
+	if err != nil {
+		t.Fatalf("LoadOrCreateConfig failed: %v", err)
+	}
+
+	if !askFnCalled {
+		t.Error("AskForConfig was not called when creating a new config")
+	}
+
+	if createdCfg.FormatVersion != testCurrentFormatVersion {
+		t.Errorf("Expected FormatVersion to be %d for new config, got %d", testCurrentFormatVersion, createdCfg.FormatVersion)
+	}
+	
+	// Ensure lock is initialized
+	if createdCfg.lock == nil {
+		createdCfg.lock = &sync.Mutex{}
+	}
+
+	err = createdCfg.Save()
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	savedCfg := loadConfigFromFile(t, configFilePath)
+	if savedCfg.FormatVersion != testCurrentFormatVersion {
+		t.Errorf("Expected FormatVersion in saved file to be %d, got %d", testCurrentFormatVersion, savedCfg.FormatVersion)
+	}
+	if savedCfg.JiraUser != "newuser" { // Check if other data from mockAskFn was saved
+		t.Errorf("Expected JiraUser to be 'newuser', got '%s'", savedCfg.JiraUser)
+	}
+}
+
+func TestLoadConfigWithCurrentVersion(t *testing.T) {
+	configContent := fmt.Sprintf(`
+jira_user: testuser
+jira_url: https://test.jira.com
+jira_token: sometoken
+jira_project: TEST
+format_version: %d
+tasks: {}
+`, testCurrentFormatVersion)
+	configFile := createTempConfigFile(t, configContent)
+
+	mockAskFn := func() *Config {
+		t.Error("AskForConfig should not be called when a config file exists")
+		return &Config{FormatVersion: 99, lock: &sync.Mutex{}} // Should not happen
+	}
+
+	loadedCfg, err := LoadOrCreateConfig(mockAskFn)
+	if err != nil {
+		t.Fatalf("LoadOrCreateConfig failed: %v", err)
+	}
+
+	if loadedCfg.FormatVersion != testCurrentFormatVersion {
+		t.Errorf("Expected FormatVersion to be %d, got %d", testCurrentFormatVersion, loadedCfg.FormatVersion)
+	}
+
+	// Ensure lock is initialized
+	if loadedCfg.lock == nil {
+		loadedCfg.lock = &sync.Mutex{}
+	}
+	
+	err = loadedCfg.Save()
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	savedCfg := loadConfigFromFile(t, configFile)
+	if savedCfg.FormatVersion != testCurrentFormatVersion {
+		t.Errorf("Expected FormatVersion in saved file to be %d, got %d", testCurrentFormatVersion, savedCfg.FormatVersion)
+	}
+}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -16,7 +16,7 @@ type Gui struct {
 }
 
 func (g *Gui) AskForConfig() *cfg.Config {
-	var cfg cfg.Config = cfg.NewConfg()
+	var cfg = cfg.NewConfg()
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewNote().Title("Welcome to gg!").
@@ -151,7 +151,7 @@ func (g *Gui) SelectTask(fetch func(bool) []cfg.Task) *cfg.Task {
 				// hackisk way to trigger reload
 				if t.Type == "dummy-all" {
 					toggleMine = !toggleMine
-					return errors.New("loading more..")
+					return errors.New("loading more")
 				}
 				return nil
 			}),


### PR DESCRIPTION
Introduces a `FormatVersion` field to the configuration file (`~/.gg`).

- Existing configurations without a version will be treated as version 1.
- New configurations will be created with the current version (version 2).
- When a configuration is saved (either new or loaded), it will be saved with the current version (version 2).

This change allows for smoother configuration migrations and updates in the future.

Includes unit tests to verify:
- Loading of existing (versionless) configs.
- Creation of new configs with the current version.
- Loading of configs already at the current version.
- Correct saving of `FormatVersion` in all scenarios.